### PR TITLE
Add support for two tariff meters (Zweitarifzähler)

### DIFF
--- a/custom_components/tibber_local/__init__.py
+++ b/custom_components/tibber_local/__init__.py
@@ -554,6 +554,22 @@ class TibberLocalBridge:
             return self._obis_values.get('0100010800ff').status
 
     @property
+    def attr0100010801ff(self) -> float:
+        return self._get_value_internal('0100010801ff')
+
+    @property
+    def attr0100010801ff_in_k(self) -> float:
+        return self._get_value_internal('0100010801ff', divisor=1000)
+
+    @property
+    def attr0100010802ff(self) -> float:
+        return self._get_value_internal('0100010802ff')
+
+    @property
+    def attr0100010802ff_in_k(self) -> float:
+        return self._get_value_internal('0100010802ff', divisor=1000)
+
+    @property
     def attr0100020800ff(self) -> float:
         return self._get_value_internal('0100020800ff')
 

--- a/custom_components/tibber_local/const.py
+++ b/custom_components/tibber_local/const.py
@@ -55,6 +55,26 @@ SENSOR_TYPES = [
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
+    # Zählerstand Tarif 1
+    SensorEntityDescription(
+        key="0100010801ff",
+        name="Import tariff 1",
+        entity_registry_enabled_default=False,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        icon="mdi:home-import-outline",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    # Zählerstand Tarif 2
+    SensorEntityDescription(
+        key="0100010802ff",
+        name="Import tariff 2",
+        entity_registry_enabled_default=False,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        icon="mdi:home-import-outline",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
     # Wirkenergie Total
     SensorEntityDescription(
         key="0100020800ff",
@@ -67,6 +87,24 @@ SENSOR_TYPES = [
     ),
     SensorEntityDescription(
         key="0100010800ff_in_k",
+        name="Import total (kWh)",
+        suggested_display_precision=5,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        icon="mdi:home-import-outline",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    SensorEntityDescription(
+        key="0100010801ff_in_k",
+        name="Import total (kWh)",
+        suggested_display_precision=5,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        icon="mdi:home-import-outline",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    SensorEntityDescription(
+        key="0100010802ff_in_k",
         name="Import total (kWh)",
         suggested_display_precision=5,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,

--- a/custom_components/tibber_local/const.py
+++ b/custom_components/tibber_local/const.py
@@ -96,7 +96,7 @@ SENSOR_TYPES = [
     ),
     SensorEntityDescription(
         key="0100010801ff_in_k",
-        name="Import total (kWh)",
+        name="Import tariff 1 (kWh)",
         suggested_display_precision=5,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         icon="mdi:home-import-outline",
@@ -105,7 +105,7 @@ SENSOR_TYPES = [
     ),
     SensorEntityDescription(
         key="0100010802ff_in_k",
-        name="Import total (kWh)",
+        name="Import tariff 2 (kWh)",
         suggested_display_precision=5,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         icon="mdi:home-import-outline",

--- a/custom_components/tibber_local/strings.json
+++ b/custom_components/tibber_local/strings.json
@@ -27,11 +27,23 @@
       "0100010800ff": {
         "name": "Import total"
       },
+      "0100010801ff": {
+        "name": "Import tariff 1"
+      },
+      "0100010802ff": {
+        "name": "Import tariff 2"
+      },
       "0100020800ff": {
         "name": "Export total"
       },
       "0100010800ff_in_k": {
         "name": "Import total (kWh)"
+      },
+      "0100010801ff_in_k": {
+        "name": "Import tarrif 1 (kWh)"
+      },
+      "0100010802ff_in_k": {
+        "name": "Import tariff 2 (kWh)"
       },
       "0100020800ff_in_k": {
         "name": "Export total (kWh)"

--- a/custom_components/tibber_local/translations/de.json
+++ b/custom_components/tibber_local/translations/de.json
@@ -43,11 +43,23 @@
       "0100010800ff": {
         "name": "Gesamtbezug (Wh)"
       },
+      "0100010801ff": {
+        "name": "Bezug Tarif 1 (Wh)"
+      },
+      "0100010802ff": {
+        "name": "Bezug Tarif 2 (Wh)"
+      },
       "0100020800ff": {
         "name": "Gesamteinspeisung (Wh)"
       },
       "0100010800ff_in_k": {
         "name": "Gesamtbezug (kWh)"
+      },
+      "0100010801ff_in_k": {
+        "name": "Bezug Tarif 1 (kWh)"
+      },
+      "0100010802ff_in_k": {
+        "name": "Bezug Tarif 2 (kWh)"
       },
       "0100020800ff_in_k": {
         "name": "Gesamteinspeisung (kWh)"

--- a/custom_components/tibber_local/translations/en.json
+++ b/custom_components/tibber_local/translations/en.json
@@ -43,11 +43,23 @@
       "0100010800ff": {
         "name": "Import total"
       },
+      "0100010801ff": {
+        "name": "Import tariff 1"
+      },
+      "0100010802ff": {
+        "name": "Import tariff 2"
+      },
       "0100020800ff": {
         "name": "Export total"
       },
       "0100010800ff_in_k": {
         "name": "Import total (kWh)"
+      },
+      "0100010801ff_in_k": {
+        "name": "Import tarrif 1 (kWh)"
+      },
+      "0100010802ff_in_k": {
+        "name": "Import tariff 2 (kWh)"
       },
       "0100020800ff_in_k": {
         "name": "Export total (kWh)"


### PR DESCRIPTION
Adds 4 new sensors:

 - `0100010801ff` "Import tariff 1"
 - `0100010802ff` "Import tariff 2"
 - `0100010801ff_in_k` "Import tariff 1 (kWh)"
 - `0100010802ff_in_k` "Import tariff 2 (kWh)"