### PR TITLE
Improving local tibber readings / fixing issues

### DIFF
--- a/custom_components/tibber_local/__init__.py
+++ b/custom_components/tibber_local/__init__.py
@@ -46,27 +46,19 @@ from .const import (
     UNKNOWN_SERIAL
 )
 from .entity import CustomFriendlyNameEntity
-from .tibber_client import TibberLocalBridge
+from .tibber_client import TibberLocalBridge, gen_log_list
 
 _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
 PLATFORMS: Final = [Platform.SENSOR]
 WEBSOCKET_WATCHDOG_INTERVAL: Final = timedelta(seconds=64)
+MASKED_KEYS: Final = ("host", "password")
 
-def mask_map(d):
-    for k, v in d.copy().items():
-        if isinstance(v, dict):
-            d.pop(k)
-            d[k] = v
-            mask_map(v)
-        else:
-            lk = k.lower()
-            if lk == "host" or lk == "password":
-                v = "<MASKED>"
-            d.pop(k)
-            d[k] = v
-    return d
+def mask_map(d: dict) -> dict:
+    # returns a copy - so we will never modify the data of the config_entry itself
+    return {k: mask_map(v) if isinstance(v, dict) else ("<MASKED>" if k.lower() in MASKED_KEYS else v)
+            for k, v in d.items()}
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     if config_entry.version < CONFIG_VERSION:
@@ -76,7 +68,8 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
                 new_data = {**config_entry.data, **config_entry.options}
             else:
                 new_data = config_entry.data
-            hass.config_entries.async_update_entry(config_entry, data=new_data, options={}, version=CONFIG_VERSION, minor_version=CONFIG_MINOR_VERSION)
+            # we migrate to 'CONFIG_VERSION.0' here - so the 'x.0 -> x.1' migration below will be executed as well
+            hass.config_entries.async_update_entry(config_entry, data=new_data, options={}, version=CONFIG_VERSION, minor_version=0)
             _LOGGER.debug(f"async_migrate_entry(): Migration to configuration version {config_entry.version}.{config_entry.minor_version} successful")
 
     if config_entry.version == 2 and config_entry.minor_version == 0:
@@ -117,9 +110,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     _LOGGER.info(f"async_setup_entry(): Starting TibberLocal - ConfigEntry: {mask_map(dict(config_entry.as_dict()))}")
 
-    if DOMAIN not in hass.data:
-        value = "UNKOWN"
-        hass.data.setdefault(DOMAIN, {"manifest_version": value})
+    hass.data.setdefault(DOMAIN, {})
 
     # if polling is NOT enabled - we will use of the websocket implementation...
     use_websocket = not config_entry.data.get(CONF_USE_POLLING, DEFAULT_USE_POLLING)
@@ -206,7 +197,7 @@ class TibberLocalDataUpdateCoordinator(DataUpdateCoordinator):
                     if self.hass is not None:
                         a_device_reg = device_reg.async_get(self.hass)
                         if a_device_reg is not None:
-                            device = a_device_reg.async_get_device(identifiers=self._device_info["identifiers"])
+                            device = a_device_reg.async_get_device(identifiers=self.get_device_info()["identifiers"])
                             if device:
                                 _LOGGER.info(f"call_later_update_device_registry(): device registry update triggered for device {device.name}")
                                 if self.bridge.ws_connected and self.bridge.ws_check_last_update():
@@ -250,12 +241,13 @@ class TibberLocalDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def start_watchdog(self, event=None):
         """Start websocket watchdog."""
-        await self._async_watchdog_check()
         self._watchdog = async_track_time_interval(self.hass, self._async_watchdog_check, WEBSOCKET_WATCHDOG_INTERVAL)
+        await self._async_watchdog_check()
 
     def stop_watchdog(self):
-        if hasattr(self, "_watchdog") and self._watchdog is not None:
+        if getattr(self, "_watchdog", None) is not None:
             self._watchdog()
+            self._watchdog = None
             async_call_later(self.hass, 5, self.call_later_update_device_registry)
 
     def _check_for_ws_task_and_cancel_if_running(self):
@@ -273,7 +265,7 @@ class TibberLocalDataUpdateCoordinator(DataUpdateCoordinator):
         """Reconnect the websocket if it fails."""
         if not self.bridge.ws_supported:
             _LOGGER.info(f"_async_watchdog_check(): Watchdog: terminated, cause bridge reported 'ws_supported' = false")
-            self._watchdog()
+            self.stop_watchdog()
         else:
             if not self.bridge.ws_connected:
                 self._check_for_ws_task_and_cancel_if_running()
@@ -306,13 +298,13 @@ class TibberLocalDataUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.warning(f"init_on_load(): caused {type(exception).__name__} - {exception}")
 
         if _LOGGER.isEnabledFor(logging.INFO):
-            _LOGGER.info(f"init_on_load(): after init - found OBIS entries: '{tibber_client.gen_log_list(bridge_data)}'")
+            _LOGGER.info(f"init_on_load(): after init - found OBIS entries: '{gen_log_list(bridge_data)}'")
 
         # was the init successful ?!
         if use_websocket:
             return self.bridge.node_device_id is not None
         else:
-            return len(bridge_data.keys()) > 0
+            return len(bridge_data) > 0
 
     async def _async_update_data(self):
         try:
@@ -352,33 +344,31 @@ class TibberLocalDataUpdateCoordinator(DataUpdateCoordinator):
 
     def _get_numeric_value_internal(self, key, divisor: int = 1) -> float|int:
         if isinstance(key, list):
-            val = None
             for a_key in key:
-                if val is None:
-                    val = self._get_numeric_value_internal(a_key, divisor)
-            return val
+                val = self._get_numeric_value_internal(a_key, divisor)
+                if val is not None:
+                    return val
+            return None
 
         if self.data is not None:
-            obis_values = self.data.get(DATA_KEY, {})
-            if key in obis_values:
-                a_obis_obj = obis_values.get(key)
-                if isinstance(a_obis_obj.value, Number):
-                    if hasattr(a_obis_obj, 'scaler'):
-                        try:
-                            return a_obis_obj.value * 10 ** int(a_obis_obj.scaler) / divisor
-                        except (TypeError, ValueError):
-                            _LOGGER.info(f"_get_numeric_value_internal(): could not convert scaler to int for key {key} - {a_obis_obj}")
-                            return None
-                    else:
-                        return a_obis_obj.value / divisor
+            a_obis_obj = self.data.get(DATA_KEY, {}).get(key)
+            if a_obis_obj is not None and isinstance(a_obis_obj.value, Number):
+                # a missing (or 'None') scaler means, that the value is not scaled at all
+                scaler = getattr(a_obis_obj, 'scaler', None)
+                if scaler is None:
+                    return a_obis_obj.value / divisor
+                try:
+                    return a_obis_obj.value * 10 ** int(scaler) / divisor
+                except (TypeError, ValueError):
+                    _LOGGER.info(f"_get_numeric_value_internal(): could not convert scaler to int for key {key} - {a_obis_obj}")
 
         return None
 
     def _get_string_internal(self, key) -> str:
         if self.data is not None:
-            obis_values = self.data.get(DATA_KEY, {})
-            if key in obis_values:
-                return obis_values.get(key).value
+            a_obis_obj = self.data.get(DATA_KEY, {}).get(key)
+            if a_obis_obj is not None:
+                return a_obis_obj.value
 
         return None
 
@@ -426,98 +416,84 @@ class TibberLocalDataUpdateCoordinator(DataUpdateCoordinator):
         else:
             return UNKNOWN_SERIAL
 
+    def _get_metrics_value_internal(self, section: str, key: str, alt_key: str = None):
+        if self.data is not None:
+            obj = self.data.get(METRICS_KEY, {}).get(section, {})
+            if key in obj:
+                return obj.get(key)
+            if alt_key is not None:
+                return obj.get(alt_key)
+
+        return None
+
+    # depending on the bridge firmware, some 'node_status' attributes are prefixed with 'node_' - or not
     @property
     def attrnode_battery_voltage(self):
-        if self.data is not None:
-            obj = self.data.get(METRICS_KEY, {}).get("node_status", {})
-            if len(obj) > 0:
-                return obj.get("battery_voltage",  obj.get("node_battery_voltage", None))
+        return self._get_metrics_value_internal("node_status", "battery_voltage", "node_battery_voltage")
 
     @property
     def attrnode_temperature(self):
-        if self.data is not None:
-            obj = self.data.get(METRICS_KEY, {}).get("node_status", {})
-            if len(obj) > 0:
-                return obj.get("temperature",  obj.get("node_temperature", None))
+        return self._get_metrics_value_internal("node_status", "temperature", "node_temperature")
 
     @property
     def attrnode_avg_rssi(self):
-        if self.data is not None:
-            obj = self.data.get(METRICS_KEY, {}).get("node_status", {})
-            if len(obj) > 0:
-                return obj.get("avg_rssi",  obj.get("node_avg_rssi", None))
+        return self._get_metrics_value_internal("node_status", "avg_rssi", "node_avg_rssi")
 
     @property
     def attrnode_avg_lqi(self):
-        if self.data is not None:
-            obj = self.data.get(METRICS_KEY, {}).get("node_status", {})
-            if len(obj) > 0:
-                return obj.get("avg_lqi", obj.get("node_avg_lqi", None))
+        return self._get_metrics_value_internal("node_status", "avg_lqi", "node_avg_lqi")
 
     @property
     def attrnode_radio_tx_power(self):
-        if self.data is not None:
-            return self.data.get(METRICS_KEY, {}).get("node_status", {}).get("radio_tx_power", None)
+        return self._get_metrics_value_internal("node_status", "radio_tx_power")
 
     @property
     def attrnode_uptime_ms(self):
-        if self.data is not None:
-            return self.data.get(METRICS_KEY, {}).get("node_status", {}).get("node_uptime_ms", None)
+        return self._get_metrics_value_internal("node_status", "node_uptime_ms")
 
     @property
     def attrnode_meter_msg_count_sent(self):
-        if self.data is not None:
-            return self.data.get(METRICS_KEY, {}).get("node_status", {}).get("meter_msg_count_sent", None)
+        return self._get_metrics_value_internal("node_status", "meter_msg_count_sent")
 
     @property
     def attrnode_meter_pkg_count_sent(self):
-        if self.data is not None:
-            return self.data.get(METRICS_KEY, {}).get("node_status", {}).get("meter_pkg_count_sent", None)
+        return self._get_metrics_value_internal("node_status", "meter_pkg_count_sent")
 
     @property
     def attrnode_time_in_em0_ms(self):
-        if self.data is not None:
-            return self.data.get(METRICS_KEY, {}).get("node_status", {}).get("time_in_em0_ms", None)
+        return self._get_metrics_value_internal("node_status", "time_in_em0_ms")
 
     @property
     def attrnode_time_in_em1_ms(self):
-        if self.data is not None:
-            return self.data.get(METRICS_KEY, {}).get("node_status", {}).get("time_in_em1_ms", None)
+        return self._get_metrics_value_internal("node_status", "time_in_em1_ms")
 
     @property
     def attrnode_time_in_em2_ms(self):
-        if self.data is not None:
-            return self.data.get(METRICS_KEY, {}).get("node_status", {}).get("time_in_em2_ms", None)
+        return self._get_metrics_value_internal("node_status", "time_in_em2_ms")
 
     @property
     def attrnode_acmp_rx_autolevel_9600(self):
-        if self.data is not None:
-            return self.data.get(METRICS_KEY, {}).get("node_status", {}).get("acmp_rx_autolevel_9600", None)
+        return self._get_metrics_value_internal("node_status", "acmp_rx_autolevel_9600")
 
     @property
     def attrnode_invalid_meter_readings_count(self):
-        if self.data is not None:
-            return self.data.get(METRICS_KEY, {}).get("node_status", {}).get("invalid_meter_readings_count", None)
+        return self._get_metrics_value_internal("node_status", "invalid_meter_readings_count")
 
     @property
     def attrhub_meter_pkg_count_recv(self):
-        if self.data is not None:
-            return self.data.get(METRICS_KEY, {}).get("hub_attachments", {}).get("meter_pkg_count_recv", None)
+        return self._get_metrics_value_internal("hub_attachments", "meter_pkg_count_recv")
 
     @property
     def attrhub_meter_reading_count_recv(self):
-        if self.data is not None:
-            return self.data.get(METRICS_KEY, {}).get("hub_attachments", {}).get("meter_reading_count_recv", None)
+        return self._get_metrics_value_internal("hub_attachments", "meter_reading_count_recv")
 
     @property
     def attrhub_meter_corrupt_reading_count_recv(self):
-        if self.data is not None:
-            return self.data.get(METRICS_KEY, {}).get("hub_attachments", {}).get("meter_corrupt_reading_count_recv", None)
+        return self._get_metrics_value_internal("hub_attachments", "meter_corrupt_reading_count_recv")
 
     @property
     def attrhub_compression_error_readings_count(self):
-        if self.data is not None:
-            return self.data.get(METRICS_KEY, {}).get("hub_attachments", {}).get("compression_error_readings_count", None)
+        return self._get_metrics_value_internal("hub_attachments", "compression_error_readings_count")
 
     @property
     def attr010060320101(self) -> str:  # XYZ
@@ -538,9 +514,11 @@ class TibberLocalDataUpdateCoordinator(DataUpdateCoordinator):
     @property
     def attr0100010800ff_status(self):
         if self.data is not None:
-            obis_values = self.data.get(DATA_KEY, {})
-            if '0100010800ff' in obis_values and hasattr(obis_values.get('0100010800ff'), 'status'):
-                return obis_values.get('0100010800ff').status
+            a_obis_obj = self.data.get(DATA_KEY, {}).get('0100010800ff')
+            if a_obis_obj is not None:
+                return getattr(a_obis_obj, 'status', None)
+
+        return None
 
     @property
     def attr0100010801ff(self) -> float|int:
@@ -697,8 +675,7 @@ class TibberLocalEntity(CustomFriendlyNameEntity):
     def __init__(
             self, coordinator: TibberLocalDataUpdateCoordinator, description: EntityDescription
     ) -> None:
-        super().__init__(coordinator, description)
-        self.coordinator = coordinator
+        super().__init__(coordinator)
         if description.entity_category != EntityCategory.DIAGNOSTIC:
             self.obis = ObisCode(description.key)
         self.entity_description = description
@@ -720,11 +697,6 @@ class TibberLocalEntity(CustomFriendlyNameEntity):
         """Return a unique ID to use for this entity."""
         sensor = self.entity_description.key
         return f"{DOMAIN}.{self._stitle}_{sensor}".lower()
-
-    async def async_added_to_hass(self):
-        """Connect to dispatcher listening for entity data notifications."""
-        self.async_on_remove(self.coordinator.async_add_listener(self.async_write_ha_state))
-        await super().async_added_to_hass()
 
     def _friendly_name_internal(self) -> str | None:
         """Return the friendly name.

--- a/custom_components/tibber_local/config_flow.py
+++ b/custom_components/tibber_local/config_flow.py
@@ -3,14 +3,13 @@ import logging
 from typing import Any
 
 import voluptuous as vol
-from aiohttp import ClientResponseError
+from aiohttp import ClientError
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.config_entries import ConfigFlowResult, SOURCE_RECONFIGURE
 from homeassistant.const import CONF_ID, CONF_HOST, CONF_NAME, CONF_SCAN_INTERVAL, CONF_PASSWORD, CONF_MODE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import slugify
-from requests.exceptions import HTTPError, Timeout
 
 from . import TibberLocalDataUpdateCoordinator
 from .const import (
@@ -36,28 +35,17 @@ from .tibber_client import TibberLocalBridge
 _LOGGER = logging.getLogger(__name__)
 
 
-@staticmethod
 def tibber_local_entries(hass: HomeAssistant):
     conf_hosts = []
     for entry in hass.config_entries.async_entries(DOMAIN):
-        a_host = entry.data[CONF_HOST]
-        a_node = entry.data[CONF_NODE_NUMBER]
-
-        if hasattr(entry, 'options'):
-            if CONF_HOST in entry.options:
-                a_host = entry.options[CONF_HOST]
-            if CONF_NODE_NUMBER in entry.options:
-                a_node = entry.options[CONF_NODE_NUMBER]
-
+        a_host = entry.options.get(CONF_HOST, entry.data.get(CONF_HOST))
+        a_node = entry.options.get(CONF_NODE_NUMBER, entry.data.get(CONF_NODE_NUMBER, DEFAULT_NODE_NUMBER))
         conf_hosts.append(f"{a_node}@@{a_host}")
     return conf_hosts
 
 
-@staticmethod
 def _host_in_configuration_exists(a_host: str, a_node, hass: HomeAssistant) -> bool:
-    if f"{a_node}@@{a_host}" in tibber_local_entries(hass):
-        return True
-    return False
+    return f"{a_node}@@{a_host}" in tibber_local_entries(hass)
 
 def _config_title_exists(a_title: str, hass: HomeAssistant) -> bool:
     return slugify(a_title) in [slugify(a_entry.title) for a_entry in hass.config_entries.async_entries(DOMAIN)]
@@ -102,7 +90,7 @@ class TibberLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._errors[CONF_HOST] = "unknown_mode"
                 _LOGGER.warning(f"_test_connection_tibber_local(): ValueError: {val_err}")
 
-        except (OSError, HTTPError, Timeout, ClientResponseError) as exc:
+        except (OSError, ClientError, asyncio.TimeoutError) as exc:
             self._errors[CONF_HOST] = "cannot_connect"
             _LOGGER.warning(f"_test_connection_tibber_local(): Could not connect to local Tibber Pulse Bridge at {host}, check host/ip address\n{type(exc).__name__} -> {exc}")
         return False
@@ -110,31 +98,26 @@ class TibberLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def _test_data_available(self, bridge: TibberLocalBridge, host: str) -> bool:
         try:
             await bridge.update_and_log()
+            if len(bridge._obis_values) == 0:
+                # a single try might be not enough - so we give the bridge a second chance
+                await asyncio.sleep(2)
+                await bridge.update_and_log()
+
+            if len(bridge._obis_values) == 0:
+                _LOGGER.warning(f"_test_data_available(): No data from Tibber Pulse Bridge at {host}")
+                self._errors[CONF_HOST] = "no_data"
+                return False
 
             # unfortunately, there is no other parser than the TibberLocalDataUpdateCoordinator,
             # so we must create a dummy one here, to be able to parse the serial data/number
             # from the found smart-meter
             coordinator = TibberLocalDataUpdateCoordinator(self.hass, None)
+            coordinator.data = {DATA_KEY: bridge._obis_values}
+            self._serial = coordinator.serial if coordinator.serial != UNKNOWN_SERIAL else self._node_device_id
+            _LOGGER.info(f"_test_data_available(): Successfully connect to local Tibber Pulse Bridge at {host} - found serial: {self._serial}")
+            return True
 
-            if len(bridge._obis_values.keys()) > 0:
-                coordinator.data = {DATA_KEY: bridge._obis_values}
-                self._serial = coordinator.serial if coordinator.serial != UNKNOWN_SERIAL else self._node_device_id
-                _LOGGER.info(f"_test_data_available(): Successfully connect to local Tibber Pulse Bridge at {host} - found serial: {self._serial}")
-                return True
-            else:
-                await asyncio.sleep(2)
-                await bridge.update_and_log()
-                if len(bridge._obis_values.keys()) > 0:
-                    coordinator.data = {DATA_KEY: bridge._obis_values}
-                    self._serial = coordinator.serial if coordinator.serial != UNKNOWN_SERIAL else self._node_device_id
-                    _LOGGER.info(f"_test_data_available(): Successfully connect to local Tibber Pulse Bridge at {host} - found serial: {self._serial}")
-                    return True
-                else:
-                    _LOGGER.warning(f"_test_data_available(): No data from Tibber Pulse Bridge at {host}")
-                    self._errors[CONF_HOST] = "no_data"
-                    return False
-
-        except (OSError, HTTPError, Timeout, ClientResponseError) as exc:
+        except (OSError, ClientError, asyncio.TimeoutError) as exc:
             self._errors[CONF_HOST] = "cannot_connect"
             _LOGGER.warning(f"_test_data_available(): Could not read data from local Tibber Pulse Bridge at {host}, check host/ip address\n{type(exc).__name__} -> {exc}")
         return False
@@ -154,18 +137,15 @@ class TibberLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         self._errors = {}
         if user_input is not None:
-            host = user_input[CONF_HOST].lower()
             # make sure we just handle host/ip's - removing http/https
-            if host.startswith("http://"):
-                host = host.replace("http://", "")
-            if host.startswith('https://'):
-                host = host.replace("https://", "")
+            host = user_input[CONF_HOST].lower().removeprefix("http://").removeprefix("https://")
 
             name = user_input[CONF_NAME]
             pwd = user_input[CONF_PASSWORD]
             use_polling = user_input[CONF_USE_POLLING]
             scan = user_input[CONF_SCAN_INTERVAL]
             node_num = user_input[CONF_NODE_NUMBER]
+            ignore_errors = user_input[CONF_IGNORE_READING_ERRORS]
 
             if self.source != SOURCE_RECONFIGURE:
                 if _config_title_exists(name, self.hass):
@@ -183,6 +163,7 @@ class TibberLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                           CONF_USE_POLLING: use_polling,
                           CONF_SCAN_INTERVAL: scan,
                           CONF_NODE_NUMBER: node_num,
+                          CONF_IGNORE_READING_ERRORS: ignore_errors,
                           CONF_ID: self._serial,
                           CONF_MODE: self._con_mode}
 

--- a/custom_components/tibber_local/const.py
+++ b/custom_components/tibber_local/const.py
@@ -246,7 +246,7 @@ SENSOR_TYPES = [
         entity_registry_enabled_default=False,
         suggested_display_precision=5,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        icon="mdi:home-import-outline",
+        icon="mdi:home-export-outline",
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),

--- a/custom_components/tibber_local/entity.py
+++ b/custom_components/tibber_local/entity.py
@@ -12,10 +12,6 @@ _LOGGER = logging.getLogger(__name__)
 
 class CustomFriendlyNameEntity(CoordinatorEntity):
 
-    def __init__(self, *args, **kwargs):
-        """Initialize and check if method exists."""
-        super().__init__(*args, **kwargs)
-
     # This is a SYNCHRONOUS method that returns a tuple, not async!
     def _Entity__async_calculate_state(self):
         """Calculate state and override ATTR_FRIENDLY_NAME."""
@@ -23,11 +19,11 @@ class CustomFriendlyNameEntity(CoordinatorEntity):
         # First let the base implementation calculate state (returns a tuple)
         result = super()._Entity__async_calculate_state()
 
-        if not USE_NEW_FRIENDLY_NAME or self._attr_has_entity_name == False:
+        if not USE_NEW_FRIENDLY_NAME or not self._attr_has_entity_name:
             return result
 
         # Check if child class implements _friendly_name_internal
-        if not hasattr(self, '_friendly_name_internal') or not callable(getattr(self, '_friendly_name_internal', None)):
+        if not callable(getattr(self, '_friendly_name_internal', None)):
             return result
 
         # Check if we have a cached friendly name that matches what we would generate

--- a/custom_components/tibber_local/sensor.py
+++ b/custom_components/tibber_local/sensor.py
@@ -19,53 +19,42 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities):
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     entities = []
-    available_sensors = None
-    if hasattr(coordinator, 'bridge' ):
-        if hasattr(coordinator.bridge, '_obis_values'):
-            if len(coordinator.bridge._obis_values) > 0:
-                available_sensors = list(coordinator.bridge._obis_values.keys())
-                _LOGGER.info(f"available obis codes found: {available_sensors}")
+    obis_values = getattr(coordinator.bridge, '_obis_values', {})
+    if len(obis_values) > 0:
+        available_sensors = list(obis_values.keys())
+        _LOGGER.info(f"available obis codes found: {available_sensors}")
 
-                # we store the available OBIS codes (so that we are able to use
-                # them later - when startup fails for some reason)
-                if len(config_entry.data.get(CONF_OBIS_CODES, [])) < len(available_sensors):
-                    new_data = config_entry.data.copy()
-                    new_data[CONF_OBIS_CODES] = available_sensors
-                    hass.config_entries.async_update_entry(config_entry, data=new_data)
-                    _LOGGER.info(f"Updated obis codes stored in config_entry: {new_data[CONF_OBIS_CODES]}")
-                else:
-                    _LOGGER.debug(f"Stored obis codes in config_entry: {config_entry.data.get(CONF_OBIS_CODES, [])}")
-            else:
-                available_sensors = config_entry.data.get(CONF_OBIS_CODES, [])
-                _LOGGER.warning(f"no sensors found @ bridge [we check, if we have stored obis codes in our config_entry: {available_sensors}]")
+        # we store the available OBIS codes (so that we are able to use
+        # them later - when startup fails for some reason)
+        if len(config_entry.data.get(CONF_OBIS_CODES, [])) < len(available_sensors):
+            new_data = dict(config_entry.data)
+            new_data[CONF_OBIS_CODES] = available_sensors
+            hass.config_entries.async_update_entry(config_entry, data=new_data)
+            _LOGGER.info(f"Updated obis codes stored in config_entry: {new_data[CONF_OBIS_CODES]}")
+        else:
+            _LOGGER.debug(f"Stored obis codes in config_entry: {config_entry.data.get(CONF_OBIS_CODES, [])}")
+    else:
+        available_sensors = config_entry.data.get(CONF_OBIS_CODES, [])
+        _LOGGER.warning(f"no sensors found @ bridge [we check, if we have stored obis codes in our config_entry: {available_sensors}]")
 
-    if available_sensors is None or len(available_sensors) == 0:
+    if len(available_sensors) == 0:
         _LOGGER.warning(f"could not detect available obis codes using just 'import total' and 'power current' as default!")
         # ok looks like, that we do not have any information about available sensors - so we just use two simple
         # obis codes 'import total' and 'power current'
         available_sensors = ["0100010800ff", "0100100700ff"]
 
     for description in SENSOR_TYPES:
+        # our metrics sensors are not OBIS based - so they will be added always
+        if description.entity_category == EntityCategory.DIAGNOSTIC:
+            entities.append(TibberLocalSensor(coordinator, description))
+            continue
+
         key = description.key
         if key.endswith("_in_k"):
-           key = key[:-5]
+            key = key[:-len("_in_k")]
 
-        if key in available_sensors:
-            entity = TibberLocalSensor(coordinator, description)
-            entities.append(entity)
-        elif hasattr(description, "aliases"):
-            if description.aliases is not None and len(description.aliases) > 0:
-                for alias in description.aliases:
-                    if alias in available_sensors:
-                        entity = TibberLocalSensor(coordinator, description)
-                        entities.append(entity)
-                        break
-
-        # make sure that our metrics sensors will be added
-        elif hasattr(description, "entity_category"):
-            if description.entity_category == EntityCategory.DIAGNOSTIC:
-                entity = TibberLocalSensor(coordinator, description)
-                entities.append(entity)
+        if key in available_sensors or any(alias in available_sensors for alias in getattr(description, "aliases", None) or []):
+            entities.append(TibberLocalSensor(coordinator, description))
 
     async_add_entities(entities)
 
@@ -78,10 +67,6 @@ class TibberLocalSensor(TibberLocalEntity, SensorEntity):
     ):
         """Initialize a singular value sensor."""
         super().__init__(coordinator=coordinator, description=description)
-        if (hasattr(self.entity_description, 'entity_registry_enabled_default')):
-            self._attr_entity_registry_enabled_default = self.entity_description.entity_registry_enabled_default
-        else:
-            self._attr_entity_registry_enabled_default = True
 
         key = self.entity_description.key.lower()
         self.entity_id = f"{Platform.SENSOR}.{slugify(self.coordinator._config_entry.title)}_{key}".lower()
@@ -89,7 +74,7 @@ class TibberLocalSensor(TibberLocalEntity, SensorEntity):
         # we use the "key" also as our internal translation-key - and EXTREMELY important we have
         self._attr_translation_key = key
 
-        if hasattr(description, 'suggested_display_precision') and description.suggested_display_precision is not None:
+        if description.suggested_display_precision is not None:
             self._attr_suggested_display_precision = description.suggested_display_precision
         else:
             self._attr_suggested_display_precision = 2
@@ -97,7 +82,7 @@ class TibberLocalSensor(TibberLocalEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         if self.coordinator.data is not None:
-            return getattr(self.coordinator, 'attr' + self.entity_description.key)
+            return getattr(self.coordinator, 'attr' + self.entity_description.key, None)
         return None
 
     # @property

--- a/custom_components/tibber_local/tibber_client.py
+++ b/custom_components/tibber_local/tibber_client.py
@@ -6,13 +6,14 @@ import re
 import time
 from asyncio import CancelledError
 from typing import Final
+from urllib.parse import urlparse
 
 import aiohttp
-from aiohttp import ClientConnectionError, ClientResponseError
+from aiohttp import ClientConnectionError, ClientResponseError, ClientTimeout
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from smllib import SmlStreamReader
-from smllib.const import UNITS, OBIS_NAMES
+from smllib.const import UNITS
 from smllib.errors import CrcError, SmlLibException
 from smllib.sml import SmlListEntry, ObisCode
 
@@ -31,189 +32,135 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-MIN_RETRY_DELAY: Final = 2.5#0.2
-MAX_RETRY_DELAY: Final = 10 #1.2
+MIN_RETRY_DELAY: Final = 2.5
+MAX_RETRY_DELAY: Final = 10
 
-class IntBasedObisCode:
-    # This is for sure a VERY STUPID Python class - but I am a NOOB - would be cool, if someone could teach me
-    # how I could fast convert my number array to the required format...
-    def __init__(self, obis_src: list, do_log_output: bool):
-        try:
-            _a = int(obis_src[1])
-            _b = int(obis_src[2])
-            _c = int(obis_src[3])
-            _d = int(obis_src[4])
-            _e = int(obis_src[5])
-            if obis_src[6] is not None and len(obis_src[6]) > 0:
-                _f = int(obis_src[6])
-            else:
-                _f = 255
+# when HA is starting, plenty of requests are running - so we grant the bridge more time for the initial read
+INITIAL_READ_TIMEOUT: Final = ClientTimeout(total=60)
+REQUEST_TIMEOUT: Final = ClientTimeout(total=10)
 
-            # self.obis_code = f'{_a}-{_b}:{_c}.{_d}.{_e}*{_f}'
-            # self.obis_short = f'{_c}.{_d}.{_e}'
-            self.obis_hex = f'{self.get_as_two_digit_hex(_a)}{self.get_as_two_digit_hex(_b)}{self.get_as_two_digit_hex(_c)}{self.get_as_two_digit_hex(_d)}{self.get_as_two_digit_hex(_e)}{self.get_as_two_digit_hex(_f)}'
-        except Exception as e:
-            if do_log_output:
-                _LOGGER.warning(
-                    f"could not parse a value as int from list {obis_src} - Please check the position of your Tibber Pulse reading head (you might need to rotate it few degrees anti clock wise) - Exception: {e}")
+# if we did not receive any websocket message for that many seconds, we force a reconnect
+WS_MAX_SILENCE_IN_SEC: Final = 50
 
-    @staticmethod
-    def get_as_two_digit_hex(input: int) -> str:
-        out = f'{input:x}'
-        if len(out) == 1:
-            return '0' + out
-        else:
-            return out
+# the coordinator will be notified at most once per second (the bridge pushes data way more often)
+WS_MIN_NOTIFY_DELAY_IN_SEC: Final = 1
+
+# 'UNITS' maps the sml unit-code to its name - here we need the opposite direction [some names are used by
+# multiple codes - like 'm³' - so we build it reversed: the first (lowest) code wins, as it did before]
+UNIT_CODE_BY_NAME: Final = {a_name: a_code for a_code, a_name in reversed(UNITS.items())}
+
+# a OBIS code consists of the six values 'a-b:c.d.e*f' - where 'f' is optional
+OBIS_DEFAULT_F_VALUE: Final = 255
 
 
-@staticmethod
-def gen_log_list(obis_values:dict)-> list:
-    a_list = []
+def obis_hex_from_parts(obis_parts: list, do_log_output: bool) -> str | None:
+    # 'a-b:c.d.e*f' -> '0100010800ff' - each of the six OBIS values is just a single byte, so the hex
+    # representation of these six bytes is already the code we are looking for
     try:
-        for a_obis in obis_values.values():
-            a_list.append(format_entry_short(a_obis))
-    except BaseException:
-        pass
-    return a_list
+        values = [int(a_value) for a_value in obis_parts[:5]]
+        values.append(int(obis_parts[5]) if obis_parts[5] else OBIS_DEFAULT_F_VALUE)
+        # 'bytes()' will raise a ValueError, if a value does not fit into a single byte
+        return bytes(values).hex()
+    except (IndexError, TypeError, ValueError) as exc:
+        if do_log_output:
+            _LOGGER.warning(f"could not build a OBIS code from {obis_parts} - Please check the position of your "
+                            f"Tibber Pulse reading head (you might need to rotate it few degrees anti clock wise) "
+                            f"- Exception: {exc}")
+    return None
 
-@staticmethod
-def format_entry(entry: SmlListEntry):
+def gen_log_list(obis_values: dict) -> list:
+    if not obis_values:
+        return []
+    return [format_entry_short(a_obis) for a_obis in obis_values.values()]
+
+def format_entry_short(entry: SmlListEntry) -> str:
     try:
-        r = f'{entry.obis.obis_code} ({entry.obis})'
-        summary = ''
+        value = entry.get_value()
         if entry.unit:
-            val = entry.get_value()
-            u = UNITS.get(entry.unit)
-            if u is None:
-                u = f' ?:{entry.unit}'
-            summary += f'{val}{u}'
-
-        desc = OBIS_NAMES.get(entry.obis)
-        if desc is not None:
-            summary += f'{" " if summary else ""}({desc})'
-        if summary:
-            r += f': {summary:s}'
-        else:
-            r += f': {entry.get_value():s}'
-        return r
-    except BaseException:
-        return 'A_ERROR_OBIS_LONG'
-
-@staticmethod
-def format_entry_short(entry: SmlListEntry):
-    try:
-        r = f'{entry.obis.obis_short} ({entry.obis})'
-        summary = ''
-        if entry.unit:
-            val = entry.get_value()
-            u = UNITS.get(entry.unit)
-            if u is None:
-                u = f' ?:{entry.unit}'
-            summary += f'{val}{u}'
-
-        if summary:
-            r += f': {summary:s}'
-        else:
-            r += f': {entry.get_value():s}'
-        return r
-    except BaseException:
+            unit = UNITS.get(entry.unit, f' ?:{entry.unit}')
+            return f'{entry.obis.obis_short} ({entry.obis}): {value}{unit}'
+        return f'{entry.obis.obis_short} ({entry.obis}): {value}'
+    except Exception:
         return 'A_ERROR_OBIS_SHORT'
 
-@staticmethod
-def ws_parse_header_string(payload_head):
-    # Parse device and topic
-    device = None
+def ws_parse_header_string(payload_head: str) -> tuple[str | None, str | None]:
+    # a header looks like: '<device:0011223344556677 topic:"sml/xyz">'
     topic = None
+    device = None
+    for a_part in payload_head.strip('<>').split():
+        if a_part.startswith('device:'):
+            device = a_part.split(':', 1)[1].lower()
+        elif a_part.startswith('topic:'):
+            topic = a_part.split(':', 1)[1].strip('"')
+    #_LOGGER.debug(f"ws_parse_header_string(): device: {device}, topic: {topic}")
+    return topic, device
+
+def ws_parse_header_bytes(sml_head: bytes) -> tuple[str | None, str | None]:
+    # 'errors=ignore' - so the decoding itself can't fail here
+    return ws_parse_header_string(sml_head.decode('ascii', errors='ignore'))
+
+def find_unit_int_from_string(unit_str: str) -> int | None:
+    return UNIT_CODE_BY_NAME.get(unit_str)
+
+def clean_host(host_input: str) -> str:
+    # ensure it looks like a URL, so 'urlparse' can handle it
+    as_url = host_input if "://" in host_input else "http://" + host_input
     try:
-        header_str = payload_head.strip('<>')
-        parts = header_str.split()
-
-        for part in parts:
-            if part.startswith('device:'):
-                device = part.split(':', 1)[1]
-            elif part.startswith('topic:'):
-                topic = part.split(':', 1)[1]
-
-        topic = topic.strip('"')
-        device = device.lower()
-        #_LOGGER.debug(f"ws_parse_header(): device: {device}, topic: {topic}")
-
-    except (UnicodeDecodeError, ValueError) as e:
-        _LOGGER.info(f"ws_parse_header_string(): Failed to parse string header: {e}")
-
-    return (topic, device)
-
-@staticmethod
-def ws_parse_header_bytes(sml_head: bytes):
-    try:
-        return ws_parse_header_string(sml_head.decode('ascii', errors='ignore'))
-    except (UnicodeDecodeError, ValueError) as e:
-        _LOGGER.info(f"ws_parse_header_bytes(): Failed to parse bytes header: {e}")
-    return None
-
-@staticmethod
-def find_unit_int_from_string(unit_str: str):
-    for aUnit in UNITS.items():
-        if aUnit[1] == unit_str:
-            return aUnit[0]
-    return None
-
-@staticmethod
-def clean_host(host_input):
-        # Ensure it looks like a URL so urlparse can handle it
-        if "://" not in host_input:
-            host_input = "http://" + host_input
-
-        from urllib.parse import urlparse
-        parsed = urlparse(host_input)
+        parsed = urlparse(as_url)
         # .hostname returns just the IP/Domain (strips port and path)
         # .netloc returns IP/Domain + port (e.g., 192.168.1.50:8080)
-        if parsed.port is not None and parsed.port != 80:
-            return f"{parsed.hostname}:{parsed.port}"
-        else:
-            return parsed.hostname
+        a_host = parsed.hostname
+        a_port = parsed.port
+    except ValueError as exc:
+        # an invalid port will cause a ValueError when accessing 'parsed.port'
+        _LOGGER.info(f"clean_host(): could not parse '{host_input}': {exc} - will use it as it is")
+        return host_input
+
+    if a_host is None:
+        return host_input
+    if a_port is not None and a_port != 80:
+        return f"{a_host}:{a_port}"
+    return a_host
 
 
 class TibberLocalBridge:
     ONLY_DIGITS: re.Pattern = re.compile("^[0-9]+$")
     PLAIN_TEXT_LINE: re.Pattern = re.compile(r'(.*?)-(.*?):(.*?)\.(.*?)\.(.*?)(?:\*(.*?)|)\((.*?)\)')
-    TWO_DIGIT_CODE_PATTERN = re.compile(r'^([^.]*\.[^.]*)(\(.*$)')
+    # matches OBIS codes with only one dot ('1-0:1.8(...)' or '1-0:1.8*255(...)') - the optional
+    # '*f' part is kept in its own group, so the missing '.e' is inserted at the right position
+    TWO_DIGIT_CODE_PATTERN: re.Pattern = re.compile(r'^([^.]*\.[^.]*?)(\*[^.(]*)?(\(.*$)')
 
-    def check_first_six_parts_for_digits_or_last_is_none(self, parts: list[str]) -> bool:
-        return (self.ONLY_DIGITS.match(parts[1]) is not None and
-                self.ONLY_DIGITS.match(parts[2]) is not None and
-                self.ONLY_DIGITS.match(parts[3]) is not None and
-                self.ONLY_DIGITS.match(parts[4]) is not None and
-                self.ONLY_DIGITS.match(parts[5]) is not None and
-                (parts[6] is None or self.ONLY_DIGITS.match(parts[6]) is not None))
+    def check_obis_parts_are_digits(self, obis_parts: list[str]) -> bool:
+        # the last part 'f' of 'a-b:c.d.e*f' is optional - so 'None' is allowed there
+        return (all(a_part is not None and self.ONLY_DIGITS.match(a_part) is not None for a_part in obis_parts[:5]) and
+                (obis_parts[5] is None or self.ONLY_DIGITS.match(obis_parts[5]) is not None))
 
     # _communication_mode 'MODE_3_SML_1_04' is the initially implemented mode (reading binary sml data)...
     # 'all' other modes have to be implemented... also it could be that the bridge does
     # not return a value for param_id=27
     def __init__(self, host, pwd, websession, node_num: int = 1, com_mode: int = MODE_3_SML_1_04, options: dict = None, coordinator: DataUpdateCoordinator = None):
 
-        if websession is not None:
-            a_host = clean_host(host)
-            _LOGGER.info(f"restarting TibberLocalBridge integration... for host: '{a_host}' node: '{node_num}' com_mode: '{com_mode}' with options: {options}")
-            self.web_session = websession
-            self.basic_auth = aiohttp.BasicAuth("admin", pwd)
-            self.url_data = f"http://{a_host}/data.json?node_id={node_num}"
-            self.url_metrics = f"http://{a_host}/metrics.json?node_id={node_num}"
-            self.url_mode = f"http://{a_host}/node_params.json?node_id={node_num}"
+        a_host = clean_host(host)
+        _LOGGER.info(f"restarting TibberLocalBridge integration... for host: '{a_host}' node: '{node_num}' com_mode: '{com_mode}' with options: {options}")
+        self.web_session = websession
+        self.basic_auth = aiohttp.BasicAuth("admin", pwd)
+        self.url_data = f"http://{a_host}/data.json?node_id={node_num}"
+        self.url_metrics = f"http://{a_host}/metrics.json?node_id={node_num}"
+        self.url_mode = f"http://{a_host}/node_params.json?node_id={node_num}"
 
-            # we must fetch the bridge nodes configuration (from all nodes) and get the one,
-            # that match the 'node_num' - since we need the 'eui'
-            self.url_metadata = f"http://{a_host}/nodes.json"
-            self.node_number = node_num
+        # we must fetch the bridge nodes configuration (from all nodes) and get the one,
+        # that match the 'node_num' - since we need the 'eui'
+        self.url_metadata = f"http://{a_host}/nodes.json"
+        self.node_number = node_num
 
-            # websocket stuff...
-            self.url_ws = f"ws://{a_host}/ws"
+        # websocket stuff...
+        self.url_ws = f"ws://{a_host}/ws"
 
-            # The 'self.ws_device_id' will be needed if multiple pulses are connected to the
-            # bridge - and the websocket does not include the node_id (node nummer), instead
-            # there is a '<device ...' header that must be used to identify the actual node.
-            # The value will be init by calling 'get_eui_for_node()'
-            self.node_device_id = None
+        # The 'self.node_device_id' will be needed if multiple pulses are connected to the
+        # bridge - and the websocket does not include the node_id (node nummer), instead
+        # there is a '<device ...' header that must be used to identify the actual node.
+        # The value will be init by calling 'get_eui_for_node()'
+        self.node_device_id = None
 
         self.ws_connected = False
         self.ws_supported = True
@@ -223,9 +170,7 @@ class TibberLocalBridge:
         self._ws_LAST_UPDATE_NOTIFY = 0
 
         self._com_mode = com_mode
-        self.ignore_parse_errors = False
-        if options is not None and "ignore_parse_errors" in options:
-            self.ignore_parse_errors = options["ignore_parse_errors"]
+        self.ignore_parse_errors = bool(options.get("ignore_parse_errors", False)) if options else False
         self._metrics_update_is_running = False
         self._LAST_METRICS_UPDATE = 0
         self._metrics_data = {}
@@ -244,19 +189,18 @@ class TibberLocalBridge:
     async def get_eui_for_node(self):
         # this must be called when we need a device_id... (when we receive data via websocket)
         try:
-            async with self.web_session.get(self.url_metadata, auth=self.basic_auth, ssl=False, timeout=10.0) as res:
-                try:
-                    res.raise_for_status()
-                    if res.status == 200:
-                        json_resp = await res.json()
-                        for a_node_obj in json_resp:
-                            if int(a_node_obj.get("node_id", -1)) == self.node_number:
-                                self.node_device_id = a_node_obj.get("eui").lower()
-                                break
-                except Exception as exec:
-                    _LOGGER.warning(f"get_eui_for_node(): access to bridge failed with INNER exception: {type({exec}).__name__} - {exec}", stack_info=True)
-        except Exception as exec:
-            _LOGGER.warning(f"get_eui_for_node(): access to bridge failed with OUTER exception: {type({exec}).__name__} - {exec}", stack_info=True)
+            async with self.web_session.get(self.url_metadata, auth=self.basic_auth, ssl=False, timeout=REQUEST_TIMEOUT) as res:
+                res.raise_for_status()
+                for a_node_obj in await res.json():
+                    if int(a_node_obj.get("node_id", -1)) == self.node_number:
+                        a_eui = a_node_obj.get("eui")
+                        if a_eui is not None:
+                            self.node_device_id = a_eui.lower()
+                        else:
+                            _LOGGER.warning(f"get_eui_for_node(): bridge does not provide a 'eui' for node {self.node_number}: {a_node_obj}")
+                        break
+        except Exception as exc:
+            _LOGGER.warning(f"get_eui_for_node(): access to bridge failed with exception: {type(exc).__name__} - {exc}")
 
     async def detect_com_mode(self):
         await self.detect_com_mode_from_node_param27()
@@ -283,40 +227,29 @@ class TibberLocalBridge:
             self._com_mode = mode_1
             _LOGGER.debug(f"detect_com_mode 1 SUCCESS -> _com_mode: {self._com_mode}")
         else:
-            if (mode_2 != -1):
-                _LOGGER.debug(f"detect_com_mode 1 is {self._com_mode}: {mode_1} failed - will try to read {mode_2}")
-                await self.read_tibber_local(mode_2, retry_count=0, log_payload=True)
-                if len(self._obis_values) > 0:
-                    self._com_mode = mode_2
-                    _LOGGER.debug(f"detect_com_mode 2 SUCCESS -> _com_mode: {self._com_mode}")
-                else:
-                    _LOGGER.debug(f"detect_com_mode 2 is {self._com_mode}: {mode_1} failed and {mode_2} failed")
-                    pass
+            _LOGGER.debug(f"detect_com_mode 1 is {self._com_mode}: {mode_1} failed - will try to read {mode_2}")
+            await self.read_tibber_local(mode_2, retry_count=0, log_payload=True)
+            if len(self._obis_values) > 0:
+                self._com_mode = mode_2
+                _LOGGER.debug(f"detect_com_mode 2 SUCCESS -> _com_mode: {self._com_mode}")
             else:
-                _LOGGER.debug(f"detect_com_mode 1 is {self._com_mode}: {mode_1} failed")
+                _LOGGER.debug(f"detect_com_mode 2 is {self._com_mode}: {mode_1} failed and {mode_2} failed")
 
     async def detect_com_mode_from_node_param27(self):
+        # {'param_id': 27, 'name': 'meter_mode', 'size': 1, 'type': 'uint8', 'help': '0:IEC 62056-21, 1:Count impressions', 'value': [3]}
+        self._com_mode = MODE_UNKNOWN
         try:
-            # {'param_id': 27, 'name': 'meter_mode', 'size': 1, 'type': 'uint8', 'help': '0:IEC 62056-21, 1:Count impressions', 'value': [3]}
-            self._com_mode = MODE_UNKNOWN
-            async with self.web_session.get(self.url_mode, auth=self.basic_auth, ssl=False, timeout=10.0) as res:
-                try:
-                    res.raise_for_status()
-                    if res.status == 200:
-                        json_resp = await res.json()
-                        for a_parm_obj in json_resp:
-                            if 'param_id' in a_parm_obj and a_parm_obj['param_id'] == 27 or \
-                                    'name' in a_parm_obj and a_parm_obj['name'] == 'meter_mode':
-                                if 'value' in a_parm_obj:
-                                    self._com_mode = a_parm_obj['value'][0]
-                                    # check for known modes in the UI (http://YOUR-IP-HERE/nodes/1/config)
-                                    if self._com_mode not in ENUM_MODES:
-                                        self._com_mode = MODE_UNKNOWN
-                                    break
-                except Exception as exec:
-                    _LOGGER.warning(f"access to bridge failed with INNER exception: {type({exec}).__name__} - {exec}", stack_info=True)
-        except Exception as exec:
-            _LOGGER.warning(f"access to bridge failed with OUTER exception: {type({exec}).__name__} - {exec}", stack_info=True)
+            async with self.web_session.get(self.url_mode, auth=self.basic_auth, ssl=False, timeout=REQUEST_TIMEOUT) as res:
+                res.raise_for_status()
+                for a_parm_obj in await res.json():
+                    if (a_parm_obj.get('param_id') == 27 or a_parm_obj.get('name') == 'meter_mode') and 'value' in a_parm_obj:
+                        self._com_mode = a_parm_obj['value'][0]
+                        # check for known modes in the UI (http://YOUR-IP-HERE/nodes/1/config)
+                        if self._com_mode not in ENUM_MODES:
+                            self._com_mode = MODE_UNKNOWN
+                        break
+        except Exception as exc:
+            _LOGGER.warning(f"detect_com_mode_from_node_param27(): access to bridge failed with exception: {type(exc).__name__} - {exc}")
 
     async def update(self):
         await self.read_tibber_local(mode=self._com_mode, retry_count=0)
@@ -327,38 +260,45 @@ class TibberLocalBridge:
 
     async def read_tibber_local(self, mode: int, retry_count: int, log_payload: bool = False):
         _LOGGER.debug(f"read_tibber_local(): start[{retry_count}] - mode: {mode} request: {self.url_data}")
-        # on init we wait up to 60 seconds till we get a reply from the bridge (when HA is starting, plenty of
-        # requests are running...
-        async with self.web_session.get(self.url_data, auth=self.basic_auth, ssl=False, timeout=60.0 if len(self._obis_values) == 0 else 10.0) as res:
-            try:
+        if mode not in ENUM_IMPLEMENTATIONS:
+            _LOGGER.warning(f"read_tibber_local(): NOT IMPLEMENTED yet! - Mode: {mode}")
+            return
+
+        try:
+            # on init we wait up to 60 seconds till we get a reply from the bridge (when HA is starting, plenty of
+            # requests are running...
+            a_timeout = INITIAL_READ_TIMEOUT if len(self._obis_values) == 0 else REQUEST_TIMEOUT
+            async with self.web_session.get(self.url_data, auth=self.basic_auth, ssl=False, timeout=a_timeout) as res:
                 res.raise_for_status()
-                if res.status == 200:
-                    if mode == MODE_3_SML_1_04:
-                        await self.mode_03_read_sml(await res.read(), retry_count, log_payload)
-
-                    elif mode == MODE_10_ImpressionsAmbient:
-                        await self.mode_10_read_json_impressions_ambient(await res.json(), retry_count, log_payload)
-
-                    elif mode == MODE_99_PLAINTEXT:
-                        await self.mode_99_read_plaintext(await res.text(), retry_count, log_payload)
-
-                    if _LOGGER.isEnabledFor(logging.DEBUG):
-                        _LOGGER.debug(f"read_tibber_local: after[{retry_count}] read - found OBIS entries: '{gen_log_list(self._obis_values)}'")
+                if mode == MODE_3_SML_1_04:
+                    payload = await res.read()
+                elif mode == MODE_10_ImpressionsAmbient:
+                    payload = await res.json()
                 else:
-                    if res is not None:
-                        _LOGGER.warning(f"access to bridge failed with code {res.status} - res: {res}")
-                    else:
-                        _LOGGER.warning(f"access to bridge failed (UNKNOWN reason - 'res' is None)")
+                    payload = await res.text()
 
-            except BaseException as exc:
-                _LOGGER.warning(f"access to bridge failed with exception: {type(exc).__name__} - {exc}")
+        except Exception as exc:
+            _LOGGER.warning(f"access to bridge failed with exception: {type(exc).__name__} - {exc}")
+            return
+
+        # the response is released at this point - so a possible retry (including its delay) will not
+        # block the connection to the bridge any longer
+        if mode == MODE_3_SML_1_04:
+            await self.mode_03_read_sml(payload, retry_count, log_payload)
+        elif mode == MODE_10_ImpressionsAmbient:
+            await self.mode_10_read_json_impressions_ambient(payload, retry_count, log_payload)
+        else:
+            await self.mode_99_read_plaintext(payload, retry_count, log_payload)
+
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug(f"read_tibber_local: after[{retry_count}] read - found OBIS entries: '{gen_log_list(self._obis_values)}'")
 
     async def mode_99_read_plaintext(self, plaintext: str, retry_count: int, log_payload: bool):
         try:
-            temp_obis_values = []
             if log_payload:
                 _LOGGER.debug(f"plaintext payload: {plaintext}")
 
+            temp_obis_values = {}
             if '\r' not in plaintext:
                 plaintext = plaintext.replace(' ', '\r')
 
@@ -367,116 +307,106 @@ class TibberLocalBridge:
                     # a patch for invalid reading?!
                     # a_line = a_line.replace('."55*', '.255*')
 
-                    # if there are not at least 2 dot's before the opening '(', we must insert a '.0' before
-                    # the opening '(' [see issue #73]
-                    if self.TWO_DIGIT_CODE_PATTERN.match(a_line):
-                        a_line = re.sub(self.TWO_DIGIT_CODE_PATTERN, r'\1.0\2', a_line)
+                    # if there are not at least 2 dot's in the obis code, we must add the missing '.0'
+                    # [see issue #73]
+                    a_line = self.TWO_DIGIT_CODE_PATTERN.sub(r'\1.0\2\3', a_line, count=1)
 
-                    # it looks like that in the format 'IEC-62056-21' there are the '1-0:' is missing ?! [this is really
-                    # a very DUMP implementation] - but we check, if the line has at least
+                    # it looks like that in the format 'IEC-62056-21' there are the '1-0:' is missing ?! - so we
+                    # check, if the line has at least
                     # 1. '(' [value start]
                     # 2. ')' [value end]
                     # 3. '*' [the unit delimiter]
                     if len(a_line) >= 4 and a_line[1] != '-' and a_line[3] != ':' and '*' in a_line and '(' in a_line and ')' in a_line:
                         a_line = '1-0:' + a_line
 
-                    # obis pattern is 'a-b:c.d.e*f'
-                    parts = re.split(self.PLAIN_TEXT_LINE, a_line)
-                    if len(parts) == 9:
-                        if self.check_first_six_parts_for_digits_or_last_is_none(parts):
-                            int_obc = IntBasedObisCode(parts, not self.ignore_parse_errors)
-                            value = parts[7]
-                            unit = None
-                            if '*' in value:
-                                val_with_unit = value.split("*")
-                                if '.' in val_with_unit[0]:
-                                    value = float(val_with_unit[0])
-                                else:
-                                    value = int(val_with_unit[0])
-
-                                # converting any "kilo" unit to base unit...
-                                # so kWh will be converted to Wh - or kV will be V
-                                if val_with_unit[1].lower()[0] == 'k':
-                                    value = value * 1000
-                                    val_with_unit[1] = val_with_unit[1][1:]
-
-                                unit = find_unit_int_from_string(val_with_unit[1])
-
-                            # creating finally the "right" object from the parsed information
-                            if hasattr(int_obc, "obis_hex"):
-                                entry = SmlListEntry()
-                                entry.obis = ObisCode(int_obc.obis_hex)
-                                entry.value = value
-                                entry.unit = unit
-                                temp_obis_values.append(entry)
-                        else:
-                            if not self.ignore_parse_errors:
-                                _LOGGER.debug(f"ignore none digits-only code: {a_line}")
-                    else:
+                    # obis pattern is 'a-b:c.d.e*f' - 'parts[0]' is the text before the match, 'parts[1:7]' are
+                    # the six obis values and 'parts[7]' is the value (including its optional unit)
+                    parts = self.PLAIN_TEXT_LINE.split(a_line)
+                    if len(parts) != 9:
                         if parts[0] == '!':
                             break
-                        elif len(parts[0]) > 0 and parts[0][0] != '/':
-                            if not self.ignore_parse_errors:
-                                _LOGGER.debug(f"unknown entry: {parts[0]} (line: '{a_line}')")
-                        # else:
-                        #    print('ignore '+ parts[0])
+                        if len(parts[0]) > 0 and parts[0][0] != '/' and not self.ignore_parse_errors:
+                            _LOGGER.debug(f"unknown entry: {parts[0]} (line: '{a_line}')")
+                        continue
 
-                except Exception as e:
+                    if not self.check_obis_parts_are_digits(parts[1:7]):
+                        if not self.ignore_parse_errors:
+                            _LOGGER.debug(f"ignore none digits-only code: {a_line}")
+                        continue
+
+                    obis_hex = obis_hex_from_parts(parts[1:7], not self.ignore_parse_errors)
+                    if obis_hex is None:
+                        continue
+
+                    value = parts[7]
+                    unit = None
+                    if '*' in value:
+                        raw_value, _, raw_unit = value.partition('*')
+                        value = float(raw_value) if '.' in raw_value else int(raw_value)
+
+                        # converting any "kilo" unit to base unit...
+                        # so kWh will be converted to Wh - or kV will be V
+                        if raw_unit[:1].lower() == 'k':
+                            value = value * 1000
+                            raw_unit = raw_unit[1:]
+
+                        unit = find_unit_int_from_string(raw_unit)
+
+                    # creating finally the "right" object from the parsed information
+                    entry = SmlListEntry()
+                    entry.obis = ObisCode(obis_hex)
+                    entry.value = value
+                    entry.unit = unit
+                    # our plaintext values are not scaled - but 'SmlListEntry.get_value()' requires the attribute
+                    entry.scaler = 0
+                    temp_obis_values[entry.obis] = entry
+
+                except Exception as exc:
                     if not self.ignore_parse_errors:
-                        _LOGGER.info(f"{e}")
+                        _LOGGER.info(f"could not process line '{a_line}': {type(exc).__name__} - {exc}")
 
+            # only replace the previous values, if we could read something
             if len(temp_obis_values) > 0:
-                self._obis_values = {}
-                #self._obis_values_by_short = {}
-                for entry in temp_obis_values:
-                    self._obis_values[entry.obis] = entry
-                    #self._obis_values_by_short[entry.obis.obis_short] = entry
+                self._obis_values = temp_obis_values
 
         except Exception as exc:
             if not self.ignore_parse_errors:
-                _LOGGER.warning(f"Exception {exc} while process data - plaintext: {plaintext}")
-            if retry_count < self.MAX_READ_RETRIES:
-                retry_count = retry_count + 1
-                await asyncio.sleep(random.uniform(MIN_RETRY_DELAY, MAX_RETRY_DELAY))
-                await self.read_tibber_local(mode=MODE_99_PLAINTEXT, retry_count=retry_count)
+                _LOGGER.warning(f"Exception {type(exc).__name__} - {exc} while process data - plaintext: {plaintext}")
+            await self._retry_read(MODE_99_PLAINTEXT, retry_count)
 
     async def mode_10_read_json_impressions_ambient(self, data: dict, retry_count: int, log_payload: bool):
         # {"$type": "imp_data", "timestamp_ms": 2122625,"delta_ms": 9879,"kw":0.364409, "kwh": 0.0040}
-        temp_obis_values = []
+        temp_obis_values = {}
 
         if log_payload:
             _LOGGER.debug(f"mode 10 payload: {data}")
 
-        if "$type" in data and data["$type"] == "imp_data":
-            if "kw" in data:
-                kw = data.get("kw")
-                if kw is not None:
-                    # this is hardcoded '0100100700ff' (Wirkleistung) - but the value in kW... and the sensor
-                    # is in W - so we have to multiply it with 1000
-                    entry = SmlListEntry()
-                    entry.obis = ObisCode('0100100700ff')
-                    entry.unit = 27 # 27 is the unit: Watt
-                    entry.scaler = 0
-                    entry.value = kw * 1000
-                    temp_obis_values.append(entry)
+        if isinstance(data, dict) and data.get("$type") == "imp_data":
+            kw = data.get("kw")
+            if kw is not None:
+                # this is hardcoded '0100100700ff' (Wirkleistung) - but the value in kW... and the sensor
+                # is in W - so we have to multiply it with 1000
+                entry = SmlListEntry()
+                entry.obis = ObisCode('0100100700ff')
+                entry.unit = 27 # 27 is the unit: Watt
+                entry.scaler = 0
+                entry.value = kw * 1000
+                temp_obis_values[entry.obis] = entry
 
-            if "kwh" in data:
-                # to do/implement...
-                kwh = data.get("kwh")
-                if kwh is not None:
-                    entry = SmlListEntry()
-                    entry.obis = ObisCode('0100010800ff')
-                    entry.unit = 30 # 30 is the unit: Wh
-                    entry.scaler = 0
-                    entry.value = kwh * 1000
-                    temp_obis_values.append(entry)
+            kwh = data.get("kwh")
+            if kwh is not None:
+                entry = SmlListEntry()
+                entry.obis = ObisCode('0100010800ff')
+                entry.unit = 30 # 30 is the unit: Wh
+                entry.scaler = 0
+                entry.value = kwh * 1000
+                temp_obis_values[entry.obis] = entry
+        else:
+            _LOGGER.debug(f"mode_10_read_json_impressions_ambient(): unexpected payload: {data}")
 
+        # only replace the previous values, if we could read something
         if len(temp_obis_values) > 0:
-            self._obis_values = {}
-            #self._obis_values_by_short = {}
-            for entry in temp_obis_values:
-                self._obis_values[entry.obis] = entry
-                #self._obis_values_by_short[entry.obis.obis_short] = entry
+            self._obis_values = temp_obis_values
 
     async def mode_03_read_sml(self, payload: bytes, retry_count: int, log_payload: bool):
         # for whatever reason, the data that can be read from the TibberPulse Webserver is
@@ -493,99 +423,87 @@ class TibberLocalBridge:
             if sml_frame is None:
                 if not self.ignore_parse_errors:
                     _LOGGER.info(f"Bytes missing - payload: {payload}")
-                if retry_count < self.MAX_READ_RETRIES:
-                    retry_count = retry_count + 1
-                    await asyncio.sleep(random.uniform(MIN_RETRY_DELAY, MAX_RETRY_DELAY))
-                    await self.read_tibber_local(mode=MODE_3_SML_1_04, retry_count=retry_count)
-            else:
-                use_fallback_impl = self._use_fallback_by_default
-                sml_list = None
-                a_source_exc = None
+                await self._retry_read(MODE_3_SML_1_04, retry_count)
+                return
 
-                self._obis_values = {}
-                #self._obis_values_by_short = {}
+            use_fallback_impl = self._use_fallback_by_default
+            sml_list = None
+            a_source_exc = None
 
-                if not use_fallback_impl:
-                    try:
-                        # Shortcut to extract all values without parsing the whole frame
-                        sml_list = sml_frame.get_obis()
+            if not use_fallback_impl:
+                try:
+                    # Shortcut to extract all values without parsing the whole frame
+                    sml_list = sml_frame.get_obis()
 
-                    except SmlLibException as source_exc:
-                        use_fallback_impl = True
-                        a_source_exc = source_exc
+                except SmlLibException as source_exc:
+                    use_fallback_impl = True
+                    a_source_exc = source_exc
 
-                        # if we have multiple times the same exception, we switch to the fallback implementation
-                        self._fallback_usage_counter = self._fallback_usage_counter + 1
-                        if self._fallback_usage_counter > 20:
-                            self._use_fallback_by_default = True
+                    # if we have multiple times the same exception, we switch to the fallback implementation
+                    self._fallback_usage_counter = self._fallback_usage_counter + 1
+                    if self._fallback_usage_counter > 20:
+                        self._use_fallback_by_default = True
 
-                if use_fallback_impl:
-                    # see issue https://github.com/marq24/ha-tibber-pulse-local/issues/64
-                    # there exist some devices that can't be parsed via 'get_obis()'
-                    # see also my issue @ https://github.com/spacemanspiff2007/SmlLib/issues/28
-                    sml_list = []
-                    for msg in sml_frame.parse_frame():
-                        # we simply get through all message bodies and check if we can find the 'val_list' - if so
-                        # we just add them to our result.
-                        for val in getattr(msg.message_body, 'val_list', []):
-                            sml_list.append(val)
+            if use_fallback_impl:
+                # see issue https://github.com/marq24/ha-tibber-pulse-local/issues/64
+                # there exist some devices that can't be parsed via 'get_obis()'
+                # see also my issue @ https://github.com/spacemanspiff2007/SmlLib/issues/28
+                sml_list = []
+                for msg in sml_frame.parse_frame():
+                    # we simply get through all message bodies and check if we can find the 'val_list' - if so
+                    # we just add them to our result.
+                    for val in getattr(msg.message_body, 'val_list', []):
+                        sml_list.append(val)
 
-                    if a_source_exc is not None and len(sml_list) == 0 and not self.ignore_parse_errors:
-                        _LOGGER.debug(f"Exception {a_source_exc} while 'sml_frame.get_obis()' (frame parsing did not work either) - payload: {payload}")
+                if a_source_exc is not None and len(sml_list) == 0 and not self.ignore_parse_errors:
+                    _LOGGER.debug(f"Exception {a_source_exc} while 'sml_frame.get_obis()' (frame parsing did not work either) - payload: {payload}")
 
-                # if we have a list of SML entries, we can process them
-                if sml_list is not None and len(sml_list) > 0:
-                    for entry in sml_list:
-                        self._obis_values[entry.obis] = entry
-                        #self._obis_values_by_short[entry.obis.obis_short] = entry
+            # if we have a list of SML entries, we can process them - only replacing the previous values, if we
+            # could read something [a single invalid frame should not clear all our sensor states]
+            if sml_list:
+                self._obis_values = {entry.obis: entry for entry in sml_list}
 
-        except (CrcError, BaseException) as exc:
+        except CrcError:
             if not self.ignore_parse_errors:
-                if isinstance(exc, CrcError):
-                    _LOGGER.info(f"CRC while parse data - payload: {payload}")
-                else:
-                    _LOGGER.warning(f"Exception {type(exc).__name__} - {exc} while parse data - payload: {payload}")
+                _LOGGER.info(f"CRC while parse data - payload: {payload}")
+            await self._retry_read(MODE_3_SML_1_04, retry_count)
 
-            if retry_count < self.MAX_READ_RETRIES:
-                retry_count = retry_count + 1
-                await asyncio.sleep(random.uniform(MIN_RETRY_DELAY, MAX_RETRY_DELAY))
-                await self.read_tibber_local(mode=MODE_3_SML_1_04, retry_count=retry_count)
+        except Exception as exc:
+            if not self.ignore_parse_errors:
+                _LOGGER.warning(f"Exception {type(exc).__name__} - {exc} while parse data - payload: {payload}")
+            await self._retry_read(MODE_3_SML_1_04, retry_count)
+
+    async def _retry_read(self, mode: int, retry_count: int):
+        if retry_count < self.MAX_READ_RETRIES:
+            await asyncio.sleep(random.uniform(MIN_RETRY_DELAY, MAX_RETRY_DELAY))
+            await self.read_tibber_local(mode=mode, retry_count=retry_count + 1)
 
     async def updated_tibber_metrics_if_needed(self, log_payload: bool = False):
-        if not self._metrics_update_is_running:
-            self._metrics_update_is_running = True
-            try:
-                # only request every 30 minutes (= 30 * 60sec) for new meta_data...
-                to_wait_till = self._LAST_METRICS_UPDATE + 1800
-                if to_wait_till < time.time():
-                    _LOGGER.debug(f"updated_tibber_metrics_if_needed(): request: {self.url_metrics}")
-                    async with self.web_session.get(self.url_metrics, auth=self.basic_auth, ssl=False, timeout=10.0) as res:
-                        try:
-                            res.raise_for_status()
-                            if res.status == 200:
-                                try:
-                                    self._metrics_data = await res.json()
-                                    if log_payload:
-                                        _LOGGER.debug(f"updated_tibber_metrics_if_needed(): metrics response: {self._metrics_data}")
-                                except Exception as exc:
-                                    _LOGGER.warning(f"updated_tibber_metrics_if_needed(): failed to parse metrics JSON: {exc}")
-                            else:
-                                if res is not None:
-                                    _LOGGER.warning(f"updated_tibber_metrics_if_needed(): access to bridge failed with code {res.status} - res: {res}")
-                                else:
-                                    _LOGGER.warning(f"updated_tibber_metrics_if_needed(): access to bridge failed (UNKNOWN reason - 'res' is None)")
+        if self._metrics_update_is_running:
+            return
 
-                        except BaseException as exc:
-                            _LOGGER.warning(f"updated_tibber_metrics_if_needed(): access to bridge failed with exception: {type(exc).__name__} - {exc}")
+        # only request every 30 minutes (= 30 * 60sec) for new meta_data...
+        to_wait_till = self._LAST_METRICS_UPDATE + 1800
+        if to_wait_till > time.time():
+            #_LOGGER.debug(f"updated_tibber_metrics_if_needed(): no update required [wait for: {round((to_wait_till - time.time())/60, 1)} min]")
+            return
 
-                        self._LAST_METRICS_UPDATE = time.time()
-                else:
-                    pass
-                    #_LOGGER.debug(f"updated_tibber_metrics_if_needed(): no update required [wait for: {round((to_wait_till - time.time())/60, 1)} min]")
+        self._metrics_update_is_running = True
+        try:
+            _LOGGER.debug(f"updated_tibber_metrics_if_needed(): request: {self.url_metrics}")
+            async with self.web_session.get(self.url_metrics, auth=self.basic_auth, ssl=False, timeout=REQUEST_TIMEOUT) as res:
+                res.raise_for_status()
+                self._metrics_data = await res.json()
+                if log_payload:
+                    _LOGGER.debug(f"updated_tibber_metrics_if_needed(): metrics response: {self._metrics_data}")
 
-            except BaseException as e:
-                _LOGGER.debug(f"updated_tibber_metrics_if_needed(): caused: {type(e).__name__} - {e}")
+        except Exception as exc:
+            _LOGGER.warning(f"updated_tibber_metrics_if_needed(): access to bridge failed with exception: {type(exc).__name__} - {exc}")
 
+        finally:
+            # we also mark failed attempts - so a bridge that does not provide any metrics will not be
+            # requested with every update cycle
+            self._LAST_METRICS_UPDATE = time.time()
             self._metrics_update_is_running = False
 
     # websocket implementation from here...
@@ -598,95 +516,13 @@ class TibberLocalBridge:
                 _LOGGER.info(f"ws_connect(): connected to websocket: {self.url_ws} - in COM MODE: {self._com_mode}")
                 async for msg in ws:
                     self._ws_LAST_UPDATE = time.time()
-                    new_data_arrived = False
 
-                    # self._com_mode == MODE_3_SML_1_04
-                    # self._com_mode == MODE_10_ImpressionsAmbient
-                    # self._com_mode == MODE_99_PLAINTEXT
-
-                    if msg.type == aiohttp.WSMsgType.BINARY:
-                        try:
-                            binary_data = msg.data
-                            # Find the position of '>' and extract everything after it
-                            separator_pos = binary_data.index(b'>')
-                            if separator_pos > 0:
-                                binary_head = binary_data[:separator_pos + 1]
-                                _LOGGER.debug(f"ws_connect(): WSMsgType.BINARY head: {binary_head}")
-                                topic, device_id = ws_parse_header_bytes(binary_head)
-
-                                if self.node_device_id is None or self.node_device_id == device_id:
-                                    if topic is not None and "sml" in topic.lower() and self._com_mode == MODE_3_SML_1_04:
-                                        binary_body = binary_data[separator_pos + 1:]
-                                        _LOGGER.debug(f"ws_connect(): WSMsgType.BINARY body '{topic}' [len:{len(binary_body)}]: {binary_body if len(binary_body) <= 15 else binary_body[:15]}...")
-                                        try:
-                                            await self.mode_03_read_sml(binary_body, retry_count=self.MAX_READ_RETRIES, log_payload=False)
-                                            new_data_arrived = True
-                                        except Exception as e:
-                                            _LOGGER.warning(f"ws_connect(): WSMsgType.BINARY 'mode_03_read_sml' caused {type(e).__name__} [{binary_body}] {e}")
-
-                                    elif topic is not None and self._com_mode == MODE_99_PLAINTEXT:
-                                        text_body = binary_data[separator_pos + 1:].decode('ascii', errors='ignore')
-                                        _LOGGER.debug(f"ws_connect(): WSMsgType.BINARY body (as TEXT) '{topic}' [len:{len(text_body)}]: {text_body if len(text_body) <= 15 else text_body[:15]}...")
-                                        try:
-                                            await self.mode_99_read_plaintext(text_body, retry_count=self.MAX_READ_RETRIES, log_payload=False)
-                                            new_data_arrived = True
-                                        except Exception as e:
-                                            _LOGGER.warning(f"ws_connect(): WSMsgType.BINARY 'mode_99_read_plaintext' caused {type(e).__name__} [{text_body}] {e}")
-
-                                    elif topic is not None and self._com_mode == MODE_10_ImpressionsAmbient:
-                                        json_body = binary_data[separator_pos + 1:].decode('ascii', errors='ignore')
-                                        _LOGGER.debug(f"ws_connect(): WSMsgType.BINARY body (as JSON) '{topic}' [len:{len(json_body)}]: {json_body if len(json_body) <= 15 else json_body[:15]}...")
-                                        try:
-                                            await self.mode_10_read_json_impressions_ambient(json.loads(json_body), retry_count=self.MAX_READ_RETRIES, log_payload=False)
-                                            new_data_arrived = True
-                                        except Exception as e:
-                                            _LOGGER.warning(f"ws_connect(): WSMsgType.BINARY 'mode_10_read_json_impressions_ambient' caused {type(e).__name__} [{json_body}] {e}")
-
-                                    else:
-                                        _LOGGER.warning(f"ws_connect(): WSMsgType.BINARY topic '{topic}'/mode_'{self._com_mode}' in: {binary_data}")
-                                else:
-                                    _LOGGER.debug(f"ws_connect(): WSMsgType.BINARY device of node_num '{self.node_device_id}' not matching the device in the message {device_id}")
-                            else:
-                                _LOGGER.debug(f"ws_connect(): WSMsgType.BINARY invalid data (NO '>' FOUND) in: {binary_data}")
-
-                        except Exception as e:
-                            _LOGGER.debug(f"ws_connect(): Could not read WSMsgType.BINARY from: {msg} - caused {type(e).__name__} {e}")
-
-                    elif msg.type == aiohttp.WSMsgType.TEXT:
-                        try:
-                            text_data = msg.data.decode('ascii', errors='ignore')
-                            separator_pos = text_data.index('>')
-                            if separator_pos > 0:
-                                text_head = text_data[:separator_pos + 1]
-
-                                _LOGGER.debug(f"ws_connect(): WSMsgType.TEXT head: {text_head}")
-                                topic, device_id = ws_parse_header_string(text_head)
-
-                                if self.node_device_id is None or self.node_device_id == device_id:
-                                    if topic is not None and self._com_mode == MODE_99_PLAINTEXT:
-                                        text_body = text_data[separator_pos + 1:]
-                                        _LOGGER.debug(f"ws_connect(): WSMsgType.TEXT body '{topic}' [len:{len(text_body)}]: {text_body}")
-                                        try:
-                                            await self.mode_99_read_plaintext(text_body, retry_count=self.MAX_READ_RETRIES, log_payload=False)
-                                            new_data_arrived = True
-                                        except Exception as e:
-                                            _LOGGER.warning(f"ws_connect(): WSMsgType.TEXT 'mode_99_read_plaintext' caused {type(e).__name__} [{text_data}] {e}")
-                                    else:
-                                        _LOGGER.warning(f"ws_connect(): WSMsgType.TEXT 'UNHANDLED' topic '{topic}'/mode_'{self._com_mode}' in: {text_data}")
-                                else:
-                                    _LOGGER.debug(f"ws_connect(): WSMsgType.TEXT device of node_num '{self.node_device_id}' not matching the device in the message {device_id}")
-                            else:
-                                _LOGGER.debug(f"ws_connect(): WSMsgType.TEXT invalid data (NO '>' FOUND) in: {text_data}")
-
-                        except Exception as e:
-                            _LOGGER.debug(f"ws_connect(): Could not read WSMsgType.TEXT from: {msg} - caused {type(e).__name__} {e}")
-
-                    elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
+                    if msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
                         _LOGGER.debug(f"ws_connect(): received: {msg}")
                         break
 
                     # do we need to push new data event to the coordinator?
-                    if new_data_arrived:
+                    if await self._ws_handle_message(msg):
                         await self.updated_tibber_metrics_if_needed()
                         self._ws_notify_for_new_data()
 
@@ -702,41 +538,103 @@ class TibberLocalBridge:
             _LOGGER.debug(f"ws_connect(): TimeoutError: No WebSocket message received within timeout period: {type(time_exc).__name__} - {time_exc}")
         except CancelledError as canceled:
             _LOGGER.debug(f"ws_connect(): Terminated? - {type(canceled).__name__} - {canceled}")
-        except BaseException as x:
+        except Exception as x:
             _LOGGER.error(f"ws_connect(): !!! {type(x).__name__} - {x}")
 
-        _LOGGER.debug(f"ws_connect(): -- END HAS REACHED --")
-        try:
-            await self.ws_close(ws)
-        except UnboundLocalError as is_unbound:
-            _LOGGER.debug(f"ws_connect(): skipping ws_close() (since ws is unbound)")
-        except BaseException as e:
-            _LOGGER.error(f"ws_connect(): Error while calling ws_close(): {type(e).__name__} - {e}")
+        finally:
+            _LOGGER.debug(f"ws_connect(): -- END HAS REACHED --")
+            # 'a_ws_obj' is None, if we could not connect at all (or if we have been closed already)
+            a_ws_obj = self.ws_obj
+            self.ws_connected = False
+            self.ws_obj = None
+            try:
+                await self.ws_close(a_ws_obj)
+            except Exception as e:
+                _LOGGER.error(f"ws_connect(): Error while calling ws_close(): {type(e).__name__} - {e}")
 
-        self.ws_connected = False
-        self.ws_obj = None
-        return None
+    async def _ws_handle_message(self, msg) -> bool:
+        # returns True, if the message contained data we could read
+        if msg.type == aiohttp.WSMsgType.BINARY:
+            payload = msg.data
+            separator = b'>'
+        elif msg.type == aiohttp.WSMsgType.TEXT:
+            # for TEXT messages aiohttp provides a 'str' already
+            payload = msg.data if isinstance(msg.data, str) else msg.data.decode('ascii', errors='ignore')
+            separator = '>'
+        else:
+            _LOGGER.debug(f"ws_connect(): ignoring message of type {msg.type}: {msg}")
+            return False
+
+        try:
+            # find the position of '>' - everything after it is the body
+            separator_pos = payload.find(separator)
+            if separator_pos <= 0:
+                _LOGGER.debug(f"ws_connect(): {msg.type.name} invalid data (NO '>' FOUND) in: {payload}")
+                return False
+
+            head = payload[:separator_pos + 1]
+            _LOGGER.debug(f"ws_connect(): {msg.type.name} head: {head}")
+            topic, device_id = ws_parse_header_string(head) if isinstance(head, str) else ws_parse_header_bytes(head)
+
+            # if multiple pulses are connected to the bridge, we must ignore the data of the other nodes
+            if self.node_device_id is not None and self.node_device_id != device_id:
+                _LOGGER.debug(f"ws_connect(): {msg.type.name} device of node_num '{self.node_device_id}' not matching the device in the message {device_id}")
+                return False
+
+            if topic is None:
+                _LOGGER.warning(f"ws_connect(): {msg.type.name} without any topic (mode_'{self._com_mode}') in: {payload}")
+                return False
+
+            body = payload[separator_pos + 1:]
+            _LOGGER.debug(f"ws_connect(): {msg.type.name} body '{topic}' [len:{len(body)}]: {body[:15]}{'...' if len(body) > 15 else ''}")
+
+            if self._com_mode == MODE_3_SML_1_04 and isinstance(body, bytes) and "sml" in topic.lower():
+                await self.mode_03_read_sml(body, retry_count=self.MAX_READ_RETRIES, log_payload=False)
+                return True
+
+            if self._com_mode == MODE_99_PLAINTEXT:
+                await self.mode_99_read_plaintext(self._as_text(body), retry_count=self.MAX_READ_RETRIES, log_payload=False)
+                return True
+
+            if self._com_mode == MODE_10_ImpressionsAmbient:
+                await self.mode_10_read_json_impressions_ambient(json.loads(self._as_text(body)), retry_count=self.MAX_READ_RETRIES, log_payload=False)
+                return True
+
+            _LOGGER.warning(f"ws_connect(): {msg.type.name} 'UNHANDLED' topic '{topic}'/mode_'{self._com_mode}' in: {payload}")
+
+        except Exception as exc:
+            _LOGGER.warning(f"ws_connect(): could not process {msg.type.name} message: {type(exc).__name__} - {exc} [{msg}]")
+
+        return False
+
+    @staticmethod
+    def _as_text(body) -> str:
+        return body if isinstance(body, str) else body.decode('ascii', errors='ignore')
 
     def _ws_notify_for_new_data(self):
+        # the bridge is pushing data quite often - so we throttle the coordinator updates. an already
+        # scheduled task will pick up the latest data by itself - so there is no need to cancel it
         if self._ws_debounced_update_task is not None and not self._ws_debounced_update_task.done():
-            self._ws_debounced_update_task.cancel()
+            return
         self._ws_debounced_update_task = asyncio.create_task(self._ws_debounce_coordinator_update())
 
     async def _ws_debounce_coordinator_update(self):
-        if self._coordinator is not None:
-            elapsed = time.time() - self._ws_LAST_NEW_DATA_NOTIFY
-            if elapsed < 1:
-                sec_to_sleep = 1 - elapsed
-                #_LOGGER.debug(f"_ws_debounce_coordinator_update(): sleeping for {sec_to_sleep} seconds before notifying for updated data")
-                await asyncio.sleep(sec_to_sleep)
+        if self._coordinator is None:
+            return
 
-            if _LOGGER.isEnabledFor(logging.DEBUG):
-                _LOGGER.debug(f"{self.url_ws} received: {gen_log_list(self._obis_values)}")
-            self._coordinator.async_set_updated_data({
-                DATA_KEY: self._obis_values,
-                METRICS_KEY: self._metrics_data
-            })
-            self._ws_LAST_UPDATE_NOTIFY = time.time()
+        elapsed = time.time() - self._ws_LAST_UPDATE_NOTIFY
+        if elapsed < WS_MIN_NOTIFY_DELAY_IN_SEC:
+            #_LOGGER.debug(f"_ws_debounce_coordinator_update(): sleeping before notifying for updated data")
+            await asyncio.sleep(WS_MIN_NOTIFY_DELAY_IN_SEC - elapsed)
+
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug(f"{self.url_ws} received: {gen_log_list(self._obis_values)}")
+
+        self._coordinator.async_set_updated_data({
+            DATA_KEY: self._obis_values,
+            METRICS_KEY: self._metrics_data
+        })
+        self._ws_LAST_UPDATE_NOTIFY = time.time()
 
     async def ws_close(self, ws):
         """Close the WebSocket connection cleanly."""
@@ -746,10 +644,9 @@ class TibberLocalBridge:
             try:
                 await ws.close()
                 _LOGGER.debug(f"ws_close(): connection closed successfully")
-            except BaseException as e:
+            except Exception as e:
                 _LOGGER.info(f"ws_close(): Error closing WebSocket connection: {type(e).__name__} - {e}")
             finally:
-                ws = None
                 self.ws_obj = None
         else:
             _LOGGER.debug(f"ws_close(): No active WebSocket connection to close (ws is None)")
@@ -760,6 +657,11 @@ class TibberLocalBridge:
 
     async def ws_close_and_prepare_to_terminate(self):
         try:
+            # a possibly scheduled coordinator update is not required any longer
+            if self._ws_debounced_update_task is not None and not self._ws_debounced_update_task.done():
+                self._ws_debounced_update_task.cancel()
+            self._ws_debounced_update_task = None
+
             if self.ws_obj is not None:
                 await self.ws_close(self.ws_obj)
                 await asyncio.sleep(4)
@@ -773,13 +675,11 @@ class TibberLocalBridge:
                 #self.websession.detach()
                 #_LOGGER.debug(f"ws_close_and_prepare_to_terminate(): websession is detached!")
 
-        except UnboundLocalError as is_unbound:
-            _LOGGER.debug(f"ws_close_and_prepare_to_terminate(): skipping (since ws is unbound) {type(is_unbound).__name__} - {is_unbound}")
-        except BaseException as e:
+        except Exception as e:
             _LOGGER.error(f"ws_close_and_prepare_to_terminate(): Error: {type(e).__name__} - {e}")
 
     def ws_check_last_update(self) -> bool:
-        if self._ws_LAST_UPDATE + 50 > time.time():
+        if self._ws_LAST_UPDATE + WS_MAX_SILENCE_IN_SEC > time.time():
             _LOGGER.debug(f"ws_check_last_update(): all good! [last update: {int(time.time()-self._ws_LAST_UPDATE)} sec ago]")
             return True
         else:


### PR DESCRIPTION
Thanks for this super nice project. I plan on using it however after looking through it I found a couple of issues which I aimed to fix here. It's a bit of a bigger one, buckle up ;) 


## Fix bridge data handling, websocket push and config flow

### Critical

- **Integration failed to set up when INFO logging is enabled.** `init_on_load()` called
  `tibber_client.gen_log_list(...)`, but only `TibberLocalBridge` was imported, so the module
  name was undefined (`NameError`). Now imports `gen_log_list`.
- **Websocket push never reached the coordinator.** `_ws_debounce_coordinator_update()` read
  `self._ws_LAST_NEW_DATA_NOTIFY`, an attribute that is never assigned anywhere, so every
  notification died with an `AttributeError` inside a fire-and-forget task. Values only refreshed
  on the polling interval. Now uses `_ws_LAST_UPDATE_NOTIFY`.
- **Debounce could starve itself.** Each incoming message cancelled the pending update task and
  started a new one, so a message stream faster than the 1 second delay postponed the update
  forever. It is now a throttle: a scheduled task is left alone and picks up the latest data.
- **All websocket TEXT frames were dropped.** aiohttp delivers `str` for `WSMsgType.TEXT`, and
  `msg.data.decode(...)` raised `AttributeError`, which was swallowed by a debug-level handler.
  Binary and text handling are now unified in `_ws_handle_message()`.

### Other bugs

- `ws_parse_header_bytes()` returned `None` on failure while the caller unpacked a 2-tuple, and
  `ws_parse_header_string()` crashed on a header without topic/device (`None.strip()`). The
  exception types both caught (`UnicodeDecodeError`, `ValueError`) could not occur.
- `CONF_IGNORE_READING_ERRORS` was asked for in the config flow but never written into the entry
  data, so "ignore reading errors" silently did nothing.
- Migration from config version 1 jumped straight to `2.1` and skipped the `2.0 -> 2.1` step that
  lower-cases the unique IDs. It now migrates to `2.0` first.
- `mask_map()` mutated the dict it was masking (`as_dict()` shares nested dicts) and re-inserted
  every key for no reason. It now returns a copy.
- A corrupt SML frame wiped all sensor states: `_obis_values` was cleared before parsing. Values
  are now only replaced when the frame produced entries; plaintext and impressions mode got the
  same treatment.
- Each entity registered its own coordinator listener in addition to the one `CoordinatorEntity`
  installs, so every update wrote the state twice. The entity description was also passed to
  `CoordinatorEntity` as its `context` argument.
- `_async_watchdog_check()` called `self._watchdog()` while it was still `None` (assigned only
  after the first check) when the bridge reports no websocket support.
- `call_later_update_device_registry()` used `self._device_info` before `get_device_info()` had
  ever built it.
- `_get_numeric_value_internal()` fed a `None` scaler into `int()` and dropped the value; the
  list variant kept iterating after the first hit.
- The config flow caught `requests.HTTPError`/`Timeout`, which aiohttp never raises (and
  `requests` is not a declared requirement), so connection errors were not reported as
  `cannot_connect`.
- `tibber_local_entries()` raised `KeyError` for entries stored without a node number.
- Plaintext: OBIS parts above 255 produced a silently corrupt code (`f'{300:x}'` is three digits
  and shifts the whole code); they are rejected now.
- Plaintext entries had no `scaler`, so `SmlListEntry.get_value()` raised and every log line
  rendered as `A_ERROR_OBIS_SHORT`. The `f'{value:s}'` format also raised on numeric values.
- The issue #73 workaround inserted the missing `.0` at the wrong position when the code carried
  a `*f` suffix: `1-0:1.8*255(...)` became `1.8*255.0` and the line was then discarded.
- Export tariff 3 (kWh) used the import icon.

### Robustness and cleanup

- Retries (2.5 to 10 second sleep, up to 5 times) ran inside the open `async with` response block,
  holding the connection to the bridge. The payload is now read and the response released before
  parsing and retrying.
- `except BaseException` (swallows `CancelledError`, `KeyboardInterrupt`) replaced with
  `except Exception`; `except (CrcError, BaseException)` was redundant and is now split.
- `type({exec}).__name__` in four log messages built a set from the exception and always printed
  `set`, and shadowed the `exec` builtin.
- `find_unit_int_from_string()` scanned all 68 unit entries per value; it now uses a prebuilt
  reverse map (first/lowest code wins, as before).
- The two-digit pattern was matched and then substituted again (two passes), and `re.split()` was
  called with an already compiled pattern.
- Websocket shutdown no longer relies on catching `UnboundLocalError`; close and flag reset moved
  into a `finally` block, and the pending update task is cancelled on unload.
- Float timeouts replaced with `ClientTimeout`, the metrics in-flight flag is reset in `finally`,
  `urlparse` moved to module level, `@staticmethod` removed from nine module-level functions.
- 16 near-identical metric properties collapsed onto one helper; dead code removed (`format_entry()`,
  the `manifest_version` placeholder, the commented-out `_obis_values_by_short` bookkeeping,
  redundant `hasattr()` guards).

### `IntBasedObisCode`

Replaced by `obis_hex_from_parts()`. Each of the six OBIS numbers of `a-b:c.d.e*f` is a single
byte, so the conversion is one expression:

```python
return bytes([a, b, c, d, e, f]).hex()   # [1, 0, 1, 8, 0, 255] -> '0100010800ff'
```

`bytes()` raises `ValueError` for anything outside 0-255, which is exactly the validation the
manual hex formatting was missing. The class also left `obis_hex` unset on failure, which forced a
`hasattr()` check at the call site; the function returns `None` instead.
```

Note: I only touched behavior described above. Diagnostic counters still use `state_class=MEASUREMENT` where `TOTAL_INCREASING` would fit better; changing it triggers HA statistics repairs for existing users, so I left it for you to decide.